### PR TITLE
Create from the commandline

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -1,0 +1,19 @@
+class Api::ItemsController < ApiController
+  before_action :authenticated?
+
+  def create
+    list = List.find_by_id(params[:list_id])
+    item = List.item.new(item_params)
+
+    if item.save
+      render json: item
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def item_params
+    params.require(:item).permit(:name)
+  end
+end

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -2,11 +2,11 @@ class Api::ItemsController < ApiController
   before_action :authenticated?
 
   def create
-    list = List.find_by_id(params[:list_id])
-    item = List.item.new(item_params)
+    @list = List.find_by_id(params[:list_id])
+    @item = @list.items.build(item_params)
 
-    if item.save
-      render json: item
+    if @item.save
+      render json: @item
     else
       render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -4,7 +4,7 @@ class Api::ItemsController < ApiController
   def create
     @list = List.find_by_id(params[:list_id])
     @item = @list.items.build(item_params)
-
+    
     if @item.save
       render json: @item
     else

--- a/app/controllers/api/lists_controller.rb
+++ b/app/controllers/api/lists_controller.rb
@@ -2,12 +2,13 @@ class Api::ListsController < ApiController
   before_action :authenticated?
 
   def create
-    list = List.find_by_id(params[:list_id])
+    @user = User.find_by_id(params[:user_id])
+    list = @user.lists.build(list_params)
 
     if list.save
-      render json: item
+      render json: list
     else
-      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: list.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/lists_controller.rb
+++ b/app/controllers/api/lists_controller.rb
@@ -1,0 +1,19 @@
+class Api::ListsController < ApiController
+  before_action :authenticated?
+
+  def create
+    list = List.find_by_id(params[:list_id])
+
+    if list.save
+      render json: item
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def list_params
+    params.require(:list).permit(:name)
+  end
+
+end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -6,4 +6,18 @@ class Api::UsersController < ApiController
     render json: users, each_serializer: UserSerializer
   end
 
+  def create
+    user = User.new(user_params)
+    if user.save
+      render json: user
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def user_params
+    params.require(:user).permit(:email, :password)
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,15 @@ Rails.application.routes.draw do
   # get 'welcome/index'
 
   namespace :api, defaults: { format: :json } do
-    resources :users
+    resources :users do
+      resources :lists
+    end
+
+    resources :lists, only: [] do
+      resources :items, only: [:create]
+    end
+
+    resources :items, only: [:destroy]
   end
 
   get 'welcome/about'

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::ItemsController, type: :controller do
+  include AuthHelper
+  let(:the_user){ FactoryGirl.create(:user, email: "britt@bloc.io")}
+  let(:the_list){ FactoryGirl.create(:list, user_id: the_user.id) }
+
+  describe "POST #create" do
+    it "returns http success" do
+      http_login
+      post :create, params: {item: {name: "test"}, list_id: the_list.id}
+      expect(response).to have_http_status(:success)
+    end
+
+    # it "increases the count of items by 1" do
+    #   expect{post :create, params: {item: {name: "test"}, list_id: the_list.id}}.to change(Item,:count).by(1)
+    # end
+  end
+
+end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe Api::ItemsController, type: :controller do
       expect(response).to have_http_status(:success)
     end
 
-    # it "increases the count of items by 1" do
-    #   expect{post :create, params: {item: {name: "test"}, list_id: the_list.id}}.to change(Item,:count).by(1)
-    # end
   end
 
 end

--- a/spec/controllers/api/lists_controller_spec.rb
+++ b/spec/controllers/api/lists_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Api::ItemsController, type: :controller do
+RSpec.describe Api::ListsController, type: :controller do
   include AuthHelper
   let(:the_user){ FactoryGirl.create(:user, email: "britt@bloc.io")}
   let(:the_list){ FactoryGirl.create(:list, user_id: the_user.id) }
@@ -8,12 +8,8 @@ RSpec.describe Api::ItemsController, type: :controller do
   describe "POST #create" do
     it "returns http success" do
       http_login
-      post :create, params: {list: {name: "test"}}
+      post :create, params: {list: {name: "test"}, user_id: the_user.id}
       expect(response).to have_http_status(:success)
     end
-
-    # it "increases the count of items by 1" do
-    #   expect{post :create, params: {item: {name: "test"}, list_id: the_list.id}}.to change(Item,:count).by(1)
-    # end
   end
 end

--- a/spec/controllers/api/lists_controller_spec.rb
+++ b/spec/controllers/api/lists_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Api::ItemsController, type: :controller do
+  include AuthHelper
+  let(:the_user){ FactoryGirl.create(:user, email: "britt@bloc.io")}
+  let(:the_list){ FactoryGirl.create(:list, user_id: the_user.id) }
+
+  describe "POST #create" do
+    it "returns http success" do
+      http_login
+      post :create, params: {list: {name: "test"}}
+      expect(response).to have_http_status(:success)
+    end
+
+    # it "increases the count of items by 1" do
+    #   expect{post :create, params: {item: {name: "test"}, list_id: the_list.id}}.to change(Item,:count).by(1)
+    # end
+  end
+end

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -11,4 +11,12 @@ RSpec.describe Api::UsersController, type: :controller do
     end
   end
 
+  describe "POST #create" do
+    it "returns http success" do
+      http_login
+      post :create, params: {user: {email: "user3@user.com", password: "pas123"}}
+      expect(response).to have_http_status(:success)
+    end
+  end
+
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :item do
-    
+    name Faker::Hacker.noun
+    list
   end
 end

--- a/spec/factories/lists.rb
+++ b/spec/factories/lists.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :list do
-    
+    name Faker::Hacker.abbreviation
+    user
   end
 end


### PR DESCRIPTION
- Modify the curl request for creating users to send a request without a password. Confirm an error message is returned, and a user is not created.
- Modify the curl request for creating users to send a request without a username. Confirm an error message is returned, and a user is not created.
- Modify the curl request for creating lists to send a request without a name. Confirm an error message is returned, and a list is not created.
- Modify the curl request for creating items to send a request without a description. Confirm an error message is returned, and an item is not created.

- 219 / 222 LOC (98.65%) covered.